### PR TITLE
remove endless loop from _write_byte

### DIFF
--- a/tm1637.py
+++ b/tm1637.py
@@ -89,24 +89,18 @@ class TM1637(object):
 
     def _write_byte(self, b):
         for i in range(8):
-            digitalWrite(self.clk, GPIO.LOW)
-            digitalWrite(self.dio, GPIO.HIGH if b & 1 else GPIO.LOW)
-            b >>= 1
-            digitalWrite(self.clk, GPIO.HIGH)
-
-        # wait for ACK
-        digitalWrite(self.clk, GPIO.LOW)
-        digitalWrite(self.dio, GPIO.HIGH)
-        digitalWrite(self.clk, GPIO.HIGH)
-        pinMode(self.dio, GPIO.INPUT)
-
-        while digitalRead(self.dio):
+            digitalWrite(self.dio,(b >> i) & 1)
             sleep(TM1637_DELAY)
-            if digitalRead(self.dio):
-                pinMode(self.dio, GPIO.OUTPUT)
-                digitalWrite(self.dio, GPIO.LOW)
-                pinMode(self.dio, GPIO.INPUT)
-        pinMode(self.dio, GPIO.OUTPUT)
+            digitalWrite(self.clk, GPIO.HIGH)
+            sleep(TM1637_DELAY)
+            digitalWrite(self.clk, GPIO.LOW)
+            sleep(TM1637_DELAY)
+
+        digitalWrite(self.clk, GPIO.LOW)
+        sleep(TM1637_DELAY)
+        digitalWrite(self.clk, GPIO.HIGH)
+        sleep(TM1637_DELAY)
+        digitalWrite(self.clk, GPIO.LOW)
 
     def brightness(self, val=None):
         """Set the display brightness 0-7."""


### PR DESCRIPTION
Hello,

thank you very much for providing this library.

I was wondering why I had a CPU usage of 40 percent and more and why my display aren't getting any updates.

I looked into the code and found this endless loop in the _write_byte method.

Then I looked into the solution from the original repository (https://github.com/mcauser/micropython-tm1637) and noticed a difference.

~~~python
def _write_byte(self, b):
    for i in range(8):
        self.dio((b >> i) & 1)
        sleep_us(TM1637_DELAY)
        self.clk(1)
        sleep_us(TM1637_DELAY)
        self.clk(0)
        sleep_us(TM1637_DELAY)
    self.clk(0)
    sleep_us(TM1637_DELAY)
    self.clk(1)
    sleep_us(TM1637_DELAY)
    self.clk(0)
    sleep_us(TM1637_DELAY)
~~~

I just changed the method and in my case it just works fine. Why is there this loop?