### PR TITLE
Add time handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ Display 2 independent numbers on either side of the (optional) colon, with leadi
 numbers(num1, num2, colon=True)
 ```
 
+Display time with colon, without leading zero in the hour value.
+```python
+t=datetime.datetime.now().time()
+time(t, colon=True, leadingZero=False)
+```
+
 Display a temperature -9 through 99 followed by degrees C.
 ```python
 temperature(num)

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ numbers(num1, num2, colon=True)
 Display time with colon, without leading zero in the hour value.
 ```python
 t = datetime.datetime.now().time()
-time(t, colon=True, leadingZero=False)
+time(t, colon=True, leading_zero=False)
 ```
 
 Display a temperature -9 through 99 followed by degrees C.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ numbers(num1, num2, colon=True)
 
 Display time with colon, without leading zero in the hour value.
 ```python
-t=datetime.datetime.now().time()
+t = datetime.datetime.now().time()
 time(t, colon=True, leadingZero=False)
 ```
 

--- a/demo.py
+++ b/demo.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # Raspberry Pi Python 3 TM1637 quad 7-segment LED display driver examples
+from datetime import datetime
 from time import sleep
 
 import tm1637
@@ -244,6 +245,11 @@ sleep(DELAY)
 
 # show "12:59"
 tm.numbers(12, 59)
+sleep(DELAY)
+
+# show "8:08"
+demo_time = datetime(2025, 1, 1, 8, 8)
+tm.time(demo_time, colon=True)
 sleep(DELAY)
 
 # show temperature '24*C'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r") as fh:
 setup(
     name='raspberrypi-tm1637',
     py_modules=['tm1637'],
-    version='1.3.7',
+    version='1.3.8',
     description='Raspberry Pi Python port from MicroPython library for TM1637 LED driver.',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tm1637.py
+++ b/tm1637.py
@@ -190,10 +190,10 @@ class TM1637(object):
         h0, h1 = divmod(time.hour, 10)
         m0, m1 = divmod(time.minute, 10)
         self.write([
-            tm.encode_digit(h0) if leadingZero or h0 != 0 else 0,
-            tm.encode_digit(h1) | 0x80 if colon else tm.encode_digit(h1),
-            tm.encode_digit(m0),
-            tm.encode_digit(m1)])
+            self.encode_digit(h0) if leadingZero or h0 != 0 else 0,
+            self.encode_digit(h1) | 0x80 if colon else self.encode_digit(h1),
+            self.encode_digit(m0),
+            self.encode_digit(m1)])
 
     def temperature(self, num):
         if num < -9:

--- a/tm1637.py
+++ b/tm1637.py
@@ -186,6 +186,15 @@ class TM1637(object):
             segments[1] |= 0x80  # colon on
         self.write(segments)
 
+    def time(self, time, colon=True, leadingZero=False):
+        h0, h1 = divmod(time.hour, 10)
+        m0, m1 = divmod(time.minute, 10)
+        self.write([
+            tm.encode_digit(h0) if leadingZero or h0 != 0 else 0,
+            tm.encode_digit(h1) | 0x80 if colon else tm.encode_digit(h1),
+            tm.encode_digit(m0),
+            tm.encode_digit(m1)])
+
     def temperature(self, num):
         if num < -9:
             self.show('lo')  # low

--- a/tm1637.py
+++ b/tm1637.py
@@ -186,11 +186,11 @@ class TM1637(object):
             segments[1] |= 0x80  # colon on
         self.write(segments)
 
-    def time(self, time, colon=True, leadingZero=False):
+    def time(self, time, colon=True, leading_zero=False):
         h0, h1 = divmod(time.hour, 10)
         m0, m1 = divmod(time.minute, 10)
         self.write([
-            self.encode_digit(h0) if leadingZero or h0 != 0 else 0,
+            self.encode_digit(h0) if leading_zero or h0 != 0 else 0,
             self.encode_digit(h1) | 0x80 if colon else self.encode_digit(h1),
             self.encode_digit(m0),
             self.encode_digit(m1)])


### PR DESCRIPTION
Displaying time without a leading zero in the hour value is not that easy, this adds a method for displaying time without a leading zero. It also provides control over the colon.